### PR TITLE
Add three required grants to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The owner requires the CREATE TABLE privilege in this case :
 grant create table to <user>;
 ```
 ---
-The schema into which ExcelTable is installed requires at least the privilegess to create sessions, procedures and types:
+The schema into which ExcelTable is installed requires at least the privileges to create sessions, procedures and types:
 ```sql
 grant
    create session,

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ The owner requires the CREATE TABLE privilege in this case :
 ```sql
 grant create table to <user>;
 ```
+---
+The schema into which ExcelTable is installed requires at least the privilegess to create sessions, procedures and types:
+```sql
+grant
+   create session,
+   create procedure,
+   create type
+to
+   <user>;
+```
+
 ---  
 In order to read encrypted files, the interface requires access to the DBMS_CRYPTO API (see PL/SQL section below).  
 The owner must therefore be granted EXECUTE privilege on it : 


### PR DESCRIPTION
The schema into which ExcelTable is installed
requires at least three privilages (create session, create package and create type). These are now
explicitely mentioned in the README.md.